### PR TITLE
Add set-extend command

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "debug": "^4.1.1",
     "lodash.partition": "^4.6.0",
     "p-map": "^4.0.0",
-    "recast": "^0.18.7",
+    "recast": "^0.20.2",
     "workspace-info": "^0.0.5"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "debug": "^4.1.1",
     "lodash.partition": "^4.6.0",
     "p-map": "^4.0.0",
-    "recast": "^0.18.7"
+    "recast": "^0.18.7",
+    "workspace-info": "^0.0.5"
   },
   "files": [
     "README.md",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -5,7 +5,7 @@ import {
 } from "./helpers";
 import pMap = require("p-map");
 import debug = require("debug");
-import * as path from "path";
+import path from "path";
 import { promises as fsPromises } from "fs";
 
 const debugFunc = debug("typescript-monorepo-toolkit");

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -256,7 +256,7 @@ export function setRootStringProp(
   propName: string,
   propValue: string | undefined
 ) {
-  let root = ast.program.body[0].expression.elements[0];
+  const root = ast.program.body[0].expression.elements[0];
 
   let propAst = root.properties.find(
     (p: { key: { value: string } }) => p.key.value === propName

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -7,6 +7,7 @@ import partition = require("lodash.partition");
 import * as debug from "debug";
 import { assertNonNull } from "./assertNonNull";
 import { parse, print } from "recast";
+import { getWorkspaceInfo } from "workspace-info";
 const debugFunc = debug("typescript-monorepo-toolkit");
 
 export function wrapAsyncCommand(command: Promise<void>) {
@@ -331,15 +332,7 @@ export async function applyTransformationOnAllPackages(
 export async function readWorkspaceInfoObject(
   projectRoot: string
 ): Promise<WorkspaceInfo> {
-  const r = await execFile(
-    "yarn",
-    ["-s", "workspaces", "info", "--json"],
-    projectRoot
-  );
-
-  try {
-    return JSON.parse(JSON.parse(r).data);
-  } catch (e) {
-    return JSON.parse(r);
-  }
+  return await getWorkspaceInfo({
+    cwd: projectRoot
+  });
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,10 +1,10 @@
 import { types } from "recast";
-import * as childProcess from "child_process";
-import * as path from "path";
+import childProcess from "child_process";
+import path from "path";
 import { promises as fsPromises, constants } from "fs";
-import * as pMap from "p-map";
-import partition = require("lodash.partition");
-import * as debug from "debug";
+import pMap from "p-map";
+import partition from "lodash.partition";
+import debug from "debug";
 import { assertNonNull } from "./assertNonNull";
 import { parse, print } from "recast";
 import { getWorkspaceInfo } from "workspace-info";
@@ -249,6 +249,35 @@ export function ensureCompositeProject(ast: any) {
   }
 
   compositeProp.value = types.builders.booleanLiteral(true);
+}
+
+export function setRootStringProp(
+  ast: any,
+  propName: string,
+  propValue: string | undefined
+) {
+  let root = ast.program.body[0].expression.elements[0];
+
+  let propAst = root.properties.find(
+    (p: { key: { value: string } }) => p.key.value === propName
+  );
+
+  if (!propAst && propValue) {
+    propAst = types.builders.objectProperty(
+      types.builders.literal(propName),
+      types.builders.stringLiteral(propValue)
+    );
+    root.properties.push(propAst);
+  }
+  if (!propValue) {
+    if (propAst) {
+      // delete prop
+      const index = root.properties.indexOf(propAst);
+      root.properties.splice(index, 1);
+    }
+  } else {
+    propAst.value = types.builders.stringLiteral(propValue);
+  }
 }
 
 export function setCompilerOptionsStringProp(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
 // How to preserve comments? use jscodeshift?
 // https://github.com/json5/json5/issues/177
 
-import * as commander from "commander";
-import * as debug from "debug";
+import commander from "commander";
+import debug from "debug";
+import path from "path";
 import {
   wrapAsyncCommand,
   applyTransformationOnAllPackages,
@@ -74,6 +75,28 @@ program
         program.tsconfigPath,
         async ast => {
           setCompilerOptionsStringProp(ast, "rootDir", newOutDir);
+        }
+      )
+    );
+  });
+
+program
+  .command("set-extend <yarn-project-root> [extendedTsconfigPath]")
+  .description(
+    "Set the compilerOptions.rootDir in all of the packages. omit new value to delete"
+  )
+  .action((yarnWorkspaceRoot, extendedTsconfigPath) => {
+    extendedTsconfigPath = path.resolve(extendedTsconfigPath);
+    wrapAsyncCommand(
+      applyTransformationOnAllPackages(
+        yarnWorkspaceRoot,
+        program.tsconfigPath,
+        async (ast, root, __, info) => {
+          const localExtendPath = path.relative(
+            extendedTsconfigPath,
+            path.resolve(root, info.location)
+          );
+          setCompilerOptionsStringProp(ast, "extends", localExtendPath);
         }
       )
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,8 +94,8 @@ program
         program.tsconfigPath,
         async (ast, root, __, info) => {
           const localExtendPath = path.relative(
-            extendedTsconfigPath,
-            path.resolve(root, info.location)
+            path.resolve(root, info.location),
+            extendedTsconfigPath
           );
           setRootStringProp(ast, "extends", localExtendPath);
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,8 @@ import path from "path";
 import {
   wrapAsyncCommand,
   applyTransformationOnAllPackages,
-  setCompilerOptionsStringProp
+  setCompilerOptionsStringProp,
+  setRootStringProp
 } from "./helpers";
 import colors = require("colors");
 import { injectRefs } from "./commands";
@@ -96,7 +97,7 @@ program
             extendedTsconfigPath,
             path.resolve(root, info.location)
           );
-          setCompilerOptionsStringProp(ast, "extends", localExtendPath);
+          setRootStringProp(ast, "extends", localExtendPath);
         }
       )
     );

--- a/src/inject.test.ts
+++ b/src/inject.test.ts
@@ -10,6 +10,7 @@ import {
 } from "./helpers";
 import jestDiff from "jest-diff";
 import * as json5 from "json5";
+import assert from "assert";
 
 describe("modify tsconfig", () => {
   test("ensure composite", async () => {
@@ -109,8 +110,8 @@ describe("setRootStringProp", () => {
 
     setRootStringProp(ast, "extends", "ciao");
 
-    const stringAfter = print(ast).code;
-    console.log(stringAfter);
+    const objectAfter = JSON.parse(print(ast).code)[0];
+    assert(objectAfter.extends === "ciao");
   });
 
   it("replace", () => {
@@ -125,7 +126,7 @@ describe("setRootStringProp", () => {
 
     setRootStringProp(ast, "extends", "another_one");
 
-    const stringAfter = print(ast).code;
-    console.log(stringAfter);
+    const objectAfter = JSON.parse(print(ast).code)[0];
+    assert(objectAfter.extends === "another_one");
   });
 });

--- a/src/inject.test.ts
+++ b/src/inject.test.ts
@@ -3,7 +3,11 @@
 import { parse, print } from "recast";
 import { promises as fsPromises } from "fs";
 import * as path from "path";
-import { ensureCompositeProject, setProjectReferences } from "./helpers";
+import {
+  ensureCompositeProject,
+  setProjectReferences,
+  setRootStringProp
+} from "./helpers";
 import jestDiff from "jest-diff";
 import * as json5 from "json5";
 
@@ -90,5 +94,38 @@ describe("modify tsconfig", () => {
     //   [31m+   \\"references\\": Object {},[39m
     //   [2m  }[22m"
     // `);
+  });
+});
+
+describe("setRootStringProp", () => {
+  it("adds missing", () => {
+    const asString = JSON.stringify({
+      compilerOptions: {},
+      include: []
+    });
+    const itsJSwinkwink = `[${asString}]`;
+
+    const ast = parse(itsJSwinkwink);
+
+    setRootStringProp(ast, "extends", "ciao");
+
+    const stringAfter = print(ast).code;
+    console.log(stringAfter);
+  });
+
+  it("replace", () => {
+    const asString = JSON.stringify({
+      compilerOptions: {},
+      include: [],
+      extends: "hello"
+    });
+    const itsJSwinkwink = `[${asString}]`;
+
+    const ast = parse(itsJSwinkwink);
+
+    setRootStringProp(ast, "extends", "another_one");
+
+    const stringAfter = print(ast).code;
+    console.log(stringAfter);
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,19 +2,19 @@
   "compilerOptions": {
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es2019", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
-    "module": "commonjs", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "target": "es2019" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */,
+    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
     "lib": [
       "es2018"
-    ], /* Specify library files to be included in the compilation. */
-    "allowJs": true, /* Allow javascript files to be compiled. */
-    "checkJs": true, /* Report errors in .js files. */
+    ] /* Specify library files to be included in the compilation. */,
+    "allowJs": true /* Allow javascript files to be compiled. */,
+    "checkJs": true /* Report errors in .js files. */,
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "./dist", /* Redirect output structure to the directory. */
+    "outDir": "./dist" /* Redirect output structure to the directory. */,
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                     /* Enable project compilation */
     // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
@@ -22,9 +22,9 @@
     // "noEmit": true,                        /* Do not emit outputs. */
     // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
     // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-    "isolatedModules": true, /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+    "isolatedModules": true /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */,
     /* Strict Type-Checking Options */
-    "strict": true, /* Enable all strict type-checking options. */
+    "strict": true /* Enable all strict type-checking options. */,
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
@@ -46,9 +46,9 @@
     "types": [
       "node",
       "jest"
-    ], /* Type declaration files to be included in compilation. */
+    ] /* Type declaration files to be included in compilation. */,
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": false, /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
     /* Source Map Options */
@@ -62,7 +62,5 @@
     /* Advanced Options */
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1309,10 +1309,12 @@ assign-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
-ast-types@0.13.2:
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.13.2.tgz#df39b677a911a83f3a049644fb74fdded23cea48"
-  integrity sha512-uWMHxJxtfj/1oZClOxDEV1sQ1HCDkA4MG8Gr69KKeBjEVH0R84WlejZ0y2DcwyBlpAEMltmVYkVgqfLFb2oyiA==
+ast-types@0.14.1:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.14.1.tgz#0b415043770d7a2cbe4b2770271cbd7d2c9f61b9"
+  integrity sha512-pfSiukbt23P1qMhNnsozLzhMLBs7EEeXqPyvPmnuZM+RMfwfqwDbSVKYflgGuVI7/VehR4oMks0igzdNAg4VeQ==
+  dependencies:
+    tslib "^2.0.1"
 
 astral-regex@^1.0.0:
   version "1.0.0"
@@ -3967,12 +3969,12 @@ realpath-native@^1.1.0:
   dependencies:
     util.promisify "^1.0.0"
 
-recast@^0.18.7:
-  version "0.18.7"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.18.7.tgz#56338a6d803c8c3b9113344440dc70d13c8a1ef7"
-  integrity sha512-qNfoxvMkW4k8jJgNCfmIES7S31MEejXcEQs57eKUcQGiJUuX7cXNOD2h+W9z0rjNun2EkKqf0WvuRtmHw4NPNg==
+recast@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.20.2.tgz#0152546463334533ce7d6d17e3cebc9e8f83ba9b"
+  integrity sha512-awmBZTpZ4465cZPTBF9bmd/GNF2p7EMBVXxbWfwWAm44PuLMu2p68DSW+a3c0iacdATt2HZCR9gHp2b8d+7Rog==
   dependencies:
-    ast-types "0.13.2"
+    ast-types "0.14.1"
     esprima "~4.0.0"
     private "^0.1.8"
     source-map "~0.6.1"
@@ -4719,7 +4721,7 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
-tslib@^2.0.0:
+tslib@^2.0.0, tslib@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
   integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -947,6 +947,21 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
+"@npmcli/map-workspaces@^0.0.0-pre.1":
+  version "0.0.0-pre.1"
+  resolved "https://registry.yarnpkg.com/@npmcli/map-workspaces/-/map-workspaces-0.0.0-pre.1.tgz#b2c38d9a78bf38e799f66d14453e7c9b72928132"
+  integrity sha512-IovEVdr17hW/Stt0kpPjz1r0ZxRX3RGah7ww3tQpi5NtyOapJwbUffWuWETyQkOjud5soC45mnjOOBtfTggtng==
+  dependencies:
+    "@npmcli/name-from-folder" "^1.0.1"
+    glob "^7.1.6"
+    minimatch "^3.0.4"
+    read-package-json-fast "^1.1.3"
+
+"@npmcli/name-from-folder@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@npmcli/name-from-folder/-/name-from-folder-1.0.1.tgz#77ecd0a4fcb772ba6fe927e2e2e155fbec2e6b1a"
+  integrity sha512-qq3oEfcLFwNfEYOQ8HLimRGKlD8WSeGEdtUa7hmzpR8Sa7haL1KVQrvgO6wqMjhWFFVjgtrh1gIxDz+P8sjUaA==
+
 "@sinonjs/commons@^1.7.0":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.1.tgz#da5fd19a5f71177a53778073978873964f49acf1"
@@ -3231,6 +3246,11 @@ json-parse-better-errors@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
   integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
 
+json-parse-even-better-errors@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.0.tgz#371873c5ffa44304a6ba12419bcfa95f404ae081"
+  integrity sha512-o3aP+RsWDJZayj1SbHNQAI8x0v3T3SKiGoZlNYfbUP1S3omJQ6i9CnqADqkSPaOAxwua4/1YWx5CM7oiChJt2Q==
+
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
@@ -3569,6 +3589,11 @@ normalize-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
+
+npm-normalize-package-bin@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz#6e79a41f23fd235c0623218228da7d9c23b8f6e2"
+  integrity sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
 
 npm-run-path@^2.0.0:
   version "2.0.2"
@@ -3917,6 +3942,14 @@ react-is@^16.12.0:
   version "16.13.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.0.tgz#0f37c3613c34fe6b37cd7f763a0d6293ab15c527"
   integrity sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA==
+
+read-package-json-fast@^1.1.3, read-package-json-fast@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/read-package-json-fast/-/read-package-json-fast-1.2.1.tgz#e8518d6f37c99eb3afc26704c5cbb50d7ead82dd"
+  integrity sha512-OFbpwnHcv74Oa5YN5WvbOBfLw6yPmPcwvyJJw/tj9cWFBF7juQUDLDSZiOjEcgzfweWeeROOmbPpNN1qm4hcRg==
+  dependencies:
+    json-parse-even-better-errors "^2.3.0"
+    npm-normalize-package-bin "^1.0.1"
 
 read-pkg@^4.0.1:
   version "4.0.1"
@@ -4686,6 +4719,11 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
+tslib@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
+  integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
+
 tsutils@^3.17.1:
   version "3.17.1"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.17.1.tgz#ed719917f11ca0dee586272b2ac49e015a2dd759"
@@ -4914,6 +4952,19 @@ word-wrap@~1.2.3:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
+workspace-info@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/workspace-info/-/workspace-info-0.0.5.tgz#4d0031cf7a931b210105b92c23b16d6e61c03216"
+  integrity sha512-hRzPZtSc/9NwZQV0DCWQkGcQJrEAFlpSJtnrele8lAcAzvl9IR02UjRrq1KjGyLuHbFh4NyGJjBMtkCh9NVbWA==
+  dependencies:
+    "@npmcli/map-workspaces" "^0.0.0-pre.1"
+    "@npmcli/name-from-folder" "^1.0.1"
+    glob "^7.1.6"
+    minimatch "^3.0.4"
+    read-package-json-fast "^1.2.1"
+    tslib "^2.0.0"
+    yargs "^15.4.1"
+
 wrap-ansi@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-5.1.0.tgz#1fd1f67235d5b6d0fee781056001bfb694c03b09"
@@ -4997,6 +5048,14 @@ yargs-parser@^18.1.0:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^18.1.2:
+  version "18.1.3"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
+  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs@^13.3.0:
   version "13.3.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.0.tgz#4c657a55e07e5f2cf947f8a366567c04a0dedc83"
@@ -5029,6 +5088,23 @@ yargs@^15.0.0:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.0"
+
+yargs@^15.4.1:
+  version "15.4.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
+  integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==
+  dependencies:
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^4.2.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^18.1.2"
 
 yarn-deduplicate@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
I added a `set-extend <yarn-project-root> [extendedTsconfigPath]` command to add the `extend` field to every `tsconfig.json` of every package

I also set the `esModuleInterop` to true in tsconfig.json and changed the `import * from` to `import default from`, this way the jest tests can be run again (because jest uses babel and babel transpiles `import * from` incorrectly)